### PR TITLE
Use request defined host in index template

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -188,9 +188,10 @@ func (a *API) DefaultHandler(w http.ResponseWriter, r *http.Request) *appError {
 		return internalServerError(err)
 	}
 	var data = struct {
+		HOST string
 		Response
 		Oracle
-	}{response, a.oracle}
+	}{r.Host, response, a.oracle}
 	if err := t.Execute(w, &data); err != nil {
 		return internalServerError(err)
 	}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>What is my IP address? &mdash; ifconfig.co</title>
+    <title>What is my IP address? &mdash; {{ .HOST }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="What is my IP address?">
     <link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
@@ -44,34 +44,34 @@
       <div class="pure-u-1 pure-u-md-1-2">
         <h2>CLI examples:</h2>
         <pre>
-$ curl ifconfig.co
+$ curl {{ .HOST }}
 {{ .IP }}
 
-$ http -b ifconfig.co
+$ http -b {{ .HOST }}
 {{ .IP }}
 
-$ wget -qO- ifconfig.co
+$ wget -qO- {{ .HOST }}
 {{ .IP }}
 
-$ fetch -qo- https://ifconfig.co
+$ fetch -qo- https://{{ .HOST }}
 {{ .IP }}</pre>
 {{ if .IsLookupCountryEnabled }}
         <h2>Country lookup:</h2>
         <pre>
-$ http ifconfig.co/country
+$ http {{ .HOST }}/country
 {{ .Country }}</pre>
 {{ end }}
 {{ if .IsLookupCityEnabled }}
         <h2>City lookup:</h2>
         <pre>
-$ http ifconfig.co/city
+$ http {{ .HOST }}/city
 {{ .City }}</pre>
 {{ end }}
       </div>
       <div class="pure-u-1 pure-u-md-1-2">
         <h2>JSON output:</h2>
         <pre>
-$ http ifconfig.co/json
+$ http {{ .HOST }}/json
 { {{ if .IsLookupCityEnabled }}
     "city": "{{ .City }}",{{ end }}{{ if .IsLookupCountryEnabled }}
     "country": "{{ .Country }}",{{ end }}{{ if .IsLookupAddrEnabled }}
@@ -84,12 +84,12 @@ $ http ifconfig.co/json
         <h2>Plain output:</h2>
         <p>Always returns the IP address including a trailing newline, regardless of user agent.</p>
         <pre>
-$ http ifconfig.co/ip
+$ http {{ .HOST }}/ip
 {{ .IP }}</pre>
 {{ if .IsLookupPortEnabled }}
         <h2>Testing port connectivity:</h2>
         <pre>
-$ http ifconfig.co/port/8080
+$ http {{ .HOST }}/port/8080
 {
     "ip": "{{ .IP }}",
     "port": 8080,


### PR DESCRIPTION
This will simplify the creation of new instances (no need to redefine index.html template to change the FQDN).