### PR TITLE
Added explicit white background color in the CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.2/grids-responsive-min.css">
     <style>
       html, .pure-g [class *= "pure-u"] {
+        background-color: white;
         font-family: "Open Sans", sans-serif;
       }
       pre {


### PR DESCRIPTION
I explicitly added the `background-color: white` required to make the web page look ok with macOS Mojave's Dark Mode. No other changes made.