### PR TITLE
Add /health endpoint

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -159,6 +159,12 @@ func (s *Server) JSONHandler(w http.ResponseWriter, r *http.Request) *appError {
 	return nil
 }
 
+func (s *Server) HealthHandler(w http.ResponseWriter, r *http.Request) *appError {
+	w.Header().Set("Content-Type", jsonMediaType)
+	w.Write([]byte(`{"status":"OK"}`))
+	return nil
+}
+
 func (s *Server) PortHandler(w http.ResponseWriter, r *http.Request) *appError {
 	response, err := s.newPortResponse(r)
 	if err != nil {
@@ -246,6 +252,9 @@ func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) Handler() http.Handler {
 	r := NewRouter()
+
+	// Health
+	r.Route("GET", "/health", s.HealthHandler)
 
 	// JSON
 	r.Route("GET", "/", s.JSONHandler).Header("Accept", jsonMediaType)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -131,6 +131,7 @@ func TestJSONHandlers(t *testing.T) {
 		{s.URL + "/port/65356", `{"error":"Invalid port: 65356"}`, 400},
 		{s.URL + "/port/31337", `{"ip":"127.0.0.1","port":31337,"reachable":true}`, 200},
 		{s.URL + "/foo", `{"error":"404 page not found"}`, 404},
+		{s.URL + "/health", `{"status":"OK"}`, 200},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I'm continuing the work on the simple deployment, it would be a great help to have a simplest possible `/health` endpoint that I can use to check if the app is still running.