### PR TITLE
Use big.Int for decimal IPs rather than uint64

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mpolden/ipd/iputil/geo"
 	"github.com/mpolden/ipd/useragent"
 
+	"math/big"
 	"net"
 	"net/http"
 	"strconv"
@@ -30,12 +31,12 @@ type Server struct {
 }
 
 type Response struct {
-	IP         net.IP `json:"ip"`
-	IPDecimal  uint64 `json:"ip_decimal"`
-	Country    string `json:"country,omitempty"`
-	CountryISO string `json:"country_iso,omitempty"`
-	City       string `json:"city,omitempty"`
-	Hostname   string `json:"hostname,omitempty"`
+	IP         net.IP   `json:"ip"`
+	IPDecimal  *big.Int `json:"ip_decimal"`
+	Country    string   `json:"country,omitempty"`
+	CountryISO string   `json:"country_iso,omitempty"`
+	City       string   `json:"city,omitempty"`
+	Hostname   string   `json:"hostname,omitempty"`
 }
 
 type PortResponse struct {

--- a/iputil/iputil.go
+++ b/iputil/iputil.go
@@ -27,12 +27,12 @@ func LookupPort(ip net.IP, port uint64) error {
 	return nil
 }
 
-func ToDecimal(ip net.IP) uint64 {
+func ToDecimal(ip net.IP) *big.Int {
 	i := big.NewInt(0)
 	if to4 := ip.To4(); to4 != nil {
 		i.SetBytes(to4)
 	} else {
 		i.SetBytes(ip)
 	}
-	return i.Uint64()
+	return i
 }

--- a/iputil/iputil_test.go
+++ b/iputil/iputil_test.go
@@ -1,21 +1,26 @@
 package iputil
 
 import (
+	"math/big"
 	"net"
 	"testing"
 )
 
 func TestToDecimal(t *testing.T) {
+	var msb = new(big.Int)
+	msb, _ = msb.SetString("80000000000000000000000000000000", 16)
+
 	var tests = []struct {
 		in  string
-		out uint64
+		out *big.Int
 	}{
-		{"127.0.0.1", 2130706433},
-		{"::1", 1},
+		{"127.0.0.1", big.NewInt(2130706433)},
+		{"::1", big.NewInt(1)},
+		{"8000::", msb},
 	}
 	for _, tt := range tests {
 		i := ToDecimal(net.ParseIP(tt.in))
-		if tt.out != i {
+		if tt.out.Cmp(i) != 0 {
 			t.Errorf("Expected %d, got %d for IP %s", tt.out, i, tt.in)
 		}
 	}


### PR DESCRIPTION
`uint64` isn't wide enough to contain IPv6 addresses, which are 128 bits long. Using `uint64` was causing almost every IPv6 address to convert to decimal incorrectly.

Your tests missed this because you only check `::1`, where the top half is entirely zeroes.

This PR changes your code to use `big.Int` instead, which does not have this problem.